### PR TITLE
keep the package dir name in site-packages as `chatie_grpc`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatie/grpc",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "gRPC for Chatie",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.js",

--- a/python/generate.sh
+++ b/python/generate.sh
@@ -8,7 +8,7 @@ shopt -s globstar
 #
 
 # Directory to write generated code to (.js and .d.ts files)
-OUT_DIR="./src/chatie-grpc"
+OUT_DIR="./src/chatie_grpc"
 [ -d ${OUT_DIR} ] || {
   mkdir -p ${OUT_DIR}
 }


### PR DESCRIPTION
When create target `chatie_grpc` dir, which will display as a `package` to be installed to the `site-packages` dir, we should keep it as a package name。

I have found this problems days ago, but try to fix it now.  During this days, I install it with `whl` file. 😂