### PR TITLE
0.15.4 version of the chatie-grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatie/grpc",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "gRPC for Chatie",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.js",


### PR DESCRIPTION
update `chatie-grpc` version to `0.15.4`.