### PR TITLE
add file stream and image stream rpc call

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ TCP hole punching
 
 ## HISTORY
 
+### v0.18 (Oct 15, 2020)
+- Add new `MessageFileStream` and `MessageImageStream` to replace the `MessageFile` and `MessageImage` method to avoid blocking nodejs event loop when sending large files ([#88](https://github.com/Chatie/grpc/pull/88)) by [@windmemory](https://github.com/windmemory)
+
 ### v0.17 (Aug 5, 2020)
 
 - Add PHPH Support ([#76](https://github.com/Chatie/grpc/pull/76) [#78](https://github.com/Chatie/grpc/pull/78)) by [@zhangchunsheng](https://github.com/zhangchunsheng)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatie/grpc",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "description": "gRPC for Chatie",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatie/grpc",
-  "version": "0.17.5",
+  "version": "0.18.0",
   "description": "gRPC for Chatie",
   "main": "dist/src/index.js",
   "typings": "dist/src/index.d.js",

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -93,7 +93,9 @@ service Puppet {
 
   rpc MessageContact (puppet.MessageContactRequest) returns (puppet.MessageContactResponse) {}
   rpc MessageFile (puppet.MessageFileRequest) returns (puppet.MessageFileResponse) {}
+  rpc MessageFileStream (puppet.MessageFileStreamRequest) returns (stream puppet.MessageFileStreamResponse) {}
   rpc MessageImage (puppet.MessageImageRequest) returns (puppet.MessageImageResponse) {}
+  rpc MessageImageStream (puppet.MessageImageStreamRequest) returns (stream puppet.MessageImageStreamResponse) {}
   rpc MessageMiniProgram (puppet.MessageMiniProgramRequest) returns (puppet.MessageMiniProgramResponse) {}
   rpc MessageUrl (puppet.MessageUrlRequest) returns (puppet.MessageUrlResponse) {}
 

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -92,8 +92,10 @@ service Puppet {
   rpc MessagePayload (puppet.MessagePayloadRequest)  returns (puppet.MessagePayloadResponse) {}
 
   rpc MessageContact (puppet.MessageContactRequest) returns (puppet.MessageContactResponse) {}
+  // @deprecated: using MessageFileStream to transfer files
   rpc MessageFile (puppet.MessageFileRequest) returns (puppet.MessageFileResponse) {}
   rpc MessageFileStream (puppet.MessageFileStreamRequest) returns (stream puppet.MessageFileStreamResponse) {}
+  // @deprecated: using MessageImageStream to transfer images
   rpc MessageImage (puppet.MessageImageRequest) returns (puppet.MessageImageResponse) {}
   rpc MessageImageStream (puppet.MessageImageStreamRequest) returns (stream puppet.MessageImageStreamResponse) {}
   rpc MessageMiniProgram (puppet.MessageMiniProgramRequest) returns (puppet.MessageMiniProgramResponse) {}

--- a/proto/wechaty/puppet/message.proto
+++ b/proto/wechaty/puppet/message.proto
@@ -56,6 +56,13 @@ message MessageImageResponse {
   string filebox = 1;
 }
 
+message MessageImageStreamRequest {
+  string id = 1;
+}
+message MessageImageStreamResponse {
+  bytes data = 1;
+}
+
 message MessageContactRequest {
   string id = 1;
 }
@@ -68,6 +75,13 @@ message MessageFileRequest {
 }
 message MessageFileResponse {
   string filebox = 1;
+}
+
+message MessageFileStreamRequest {
+  string id = 1;
+}
+message MessageFileStreamResponse {
+  bytes data = 1;
 }
 
 message MessageMiniProgramRequest {

--- a/proto/wechaty/puppet/message.proto
+++ b/proto/wechaty/puppet/message.proto
@@ -58,6 +58,7 @@ message MessageImageResponse {
 
 message MessageImageStreamRequest {
   string id = 1;
+  ImageType type = 2;
 }
 message MessageImageStreamResponse {
   bytes data = 1;

--- a/tests/puppet-server-impl.ts
+++ b/tests/puppet-server-impl.ts
@@ -133,9 +133,19 @@ export const puppetServerImpl: IPuppetServer = {
     throw new Error('not implemented.')
   },
 
+  messageFileStream: (call) => {
+    void call
+    throw new Error('not implemented.')
+  },
+
   messageImage: (call, callback) => {
     void call
     void callback
+    throw new Error('not implemented.')
+  },
+
+  messageImageStream: (call) => {
+    void call
     throw new Error('not implemented.')
   },
 


### PR DESCRIPTION
Related to https://github.com/wechaty/wechaty-puppet-hostie/issues/80

We can use stream to transfer big files to avoid disk write block.