### PR TITLE
Fix go ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         cd go
         make generate
-        rm `go env GOPATH`/src/github.com/wechaty/go-grpc/wechaty
+        rm -rf `go env GOPATH`/src/github.com/wechaty/go-grpc/wechaty
         ln -s `pwd`/generated/wechaty/ `go env GOPATH`/src/github.com/wechaty/go-grpc/wechaty
         go build -v generated/wechaty/puppet.pb.go
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,9 +30,7 @@ jobs:
       run: |
         cd go
         make generate
-        go get github.com/wechaty/go-grpc
-        ls $GOPATH/src/github.com/wechaty/go-grpc
-        mkdir -p $GOPATH/src/github.com/wechaty/go-grpc
+        rm $GOPATH/src/github.com/wechaty/go-grpc/wechaty
         ln -s `pwd`/generated/wechaty/ $GOPATH/src/github.com/wechaty/go-grpc/wechaty
         go build -v generated/wechaty/puppet.pb.go
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,8 @@ jobs:
       run: |
         cd go
         make generate
+        go get github.com/wechaty/go-grpc
+        ls $GOPATH/src/github.com/wechaty/go-grpc
         mkdir -p $GOPATH/src/github.com/wechaty/go-grpc
         ln -s `pwd`/generated/wechaty/ $GOPATH/src/github.com/wechaty/go-grpc/wechaty
         go build -v generated/wechaty/puppet.pb.go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,8 @@ jobs:
       run: |
         cd go
         make generate
+        mkdir -p $GOPATH/src/github.com/wechaty/go-grpc
+        ln -s `pwd`/generated/wechaty/ $GOPATH/src/github.com/wechaty/go-grpc/wechaty
         go build -v generated/wechaty/puppet.pb.go
 
   publish:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,8 +30,8 @@ jobs:
       run: |
         cd go
         make generate
-        rm $GOPATH/src/github.com/wechaty/go-grpc/wechaty
-        ln -s `pwd`/generated/wechaty/ $GOPATH/src/github.com/wechaty/go-grpc/wechaty
+        rm `go env GOPATH`/src/github.com/wechaty/go-grpc/wechaty
+        ln -s `pwd`/generated/wechaty/ `go env GOPATH`/src/github.com/wechaty/go-grpc/wechaty
         go build -v generated/wechaty/puppet.pb.go
 
   publish:

--- a/proto/wechaty/puppet.proto
+++ b/proto/wechaty/puppet.proto
@@ -14,6 +14,7 @@ syntax = "proto3";
 package wechaty;
 
 option java_package="io.github.wechaty.grpc";
+option go_package="github.com/wechaty/go-grpc/wechaty";
 
 import public "puppet/base.proto";
 import public "puppet/contact.proto";


### PR DESCRIPTION
由于在生成完go文件后，进行了 `go build` 但此时 `$GOPATH `里的是老版本，所以需要将新生成的目录关联过去，如果通过 `go mod`管理则无需关心此问题。

> 先修复问题，有时间再优化